### PR TITLE
Fix digicomp camera and tone down wall transparency

### DIFF
--- a/demo/claude/digicomp.lua
+++ b/demo/claude/digicomp.lua
@@ -234,12 +234,12 @@ local channelLen = lastRow.x + 8
 local zw1 = Cube(channelLen, topY - botY, 0.2, 0)
 zw1.pos = btVector3(lastRow.x / 2, (topY + botY) / 2, CHANNEL_Z + 0.1)
 zw1.col = "darkblue"
-zw1.transparency = 0.9
+zw1.transparency = 0.5
 v:add(zw1)
 local zw2 = Cube(channelLen, topY - botY, 0.2, 0)
 zw2.pos = btVector3(lastRow.x / 2, (topY + botY) / 2, -CHANNEL_Z - 0.1)
 zw2.col = "darkblue"
-zw2.transparency = 0.9
+zw2.transparency = 0.5
 v:add(zw2)
 
 -- ---------------------------------------------------------------------
@@ -366,5 +366,5 @@ v:postSim(function(N)
 end)
 
 common.setCamera(btVector3(2.62242, 15.8954, -28.7863),
-                 btVector3(499.773, -581198, 813722), nil,
+                 btVector3(centerX, centerY, 0), nil,
                  { up = btVector3(0.00180565, 0.81375, 0.581213) })


### PR DESCRIPTION
## Summary
- The Z-confinement walls in `demo/claude/digicomp.lua` had `transparency = 0.9` (barely visible); lowered to `0.5` for a genuinely semi-transparent "glass" look, so the toggle mechanism, funnels, and balls read clearly through it.
- Fixed the camera's `look` target, which had been set to `btVector3(499.773, -581198, 813722)` — a vector with no relation to the rig's actual scale (the whole staircase spans roughly 0-7 in X and -11 to 3 in Y). That produced a degenerate camera direction and rendered fully black. Replaced it with the rig's own computed center, `btVector3(centerX, centerY, 0)`.

## Test plan
- [x] Headless run confirms the binary counter still counts correctly ball-by-ball (verified via console output through several balls/toggle flips)
- [x] Exported the scene and rendered a frame with POV-Ray — confirms the camera now frames the whole staircase, and the walls render as a semi-transparent dark-blue panel with the mechanism visible behind them

🤖 Generated with [Claude Code](https://claude.com/claude-code)